### PR TITLE
Add progress bars to ship builder

### DIFF
--- a/ship_builder_cli.py
+++ b/ship_builder_cli.py
@@ -31,6 +31,32 @@ class ShipBuilder:
         self.phaser_banks = load_phaser_banks_from_json('components/phaser_banks/phaser_banks.json')
         self.photon_torpedoes = load_photon_torpedoes_from_json('components/photon_torpedoes/photon_torpedoes.json')
 
+    def _progress_bar(self, current, limit, length=20):
+        """Return an ASCII progress bar string."""
+        if limit == 0:
+            return '[N/A]'
+        ratio = min(current / limit, 1)
+        filled = int(ratio * length)
+        bar = '#' * filled + '-' * (length - filled)
+        return f'[{bar}] {current}/{limit}'
+
+    def _display_progress(self, ship_class, components):
+        """Display running totals versus class limits."""
+        total_mass = sum(c.mass for c in components)
+        total_volume = sum(c.volume for c in components)
+        total_power_draw = sum(getattr(c, 'power_draw', 0) for c in components)
+        total_crew = sum(c.crew_required for c in components)
+        warp_core = next((c for c in components if c.type == 'warp_core'), None)
+        power_output = warp_core.power_output if warp_core else 0
+
+        print('\nCurrent Ship Stats:')
+        print(' Mass       :', self._progress_bar(total_mass, ship_class.hull_mass_limit))
+        print(' Volume     :', self._progress_bar(total_volume, ship_class.volume_capacity))
+        print(' Power Draw :', self._progress_bar(total_power_draw, ship_class.power_handling_cap))
+        print(' Crew       :', self._progress_bar(total_crew, ship_class.crew_capacity))
+        if warp_core:
+            print(f' Power Out  : {power_output}')
+
     def _select(self, options, prompt):
         print(prompt)
         for i, option in enumerate(options, start=1):
@@ -44,19 +70,29 @@ class ShipBuilder:
 
         components = []
         components.append(self._select(self.warp_cores, '\nSelect warp core:'))
+        self._display_progress(ship_class, components)
         components.append(self._select(self.warp_drives, '\nSelect warp drive:'))
+        self._display_progress(ship_class, components)
         components.append(self._select(self.life_support, '\nSelect life support system:'))
+        self._display_progress(ship_class, components)
         components.append(self._select(self.deflectors, '\nSelect deflector:'))
+        self._display_progress(ship_class, components)
         components.append(self._select(self.impulse_engines, '\nSelect impulse drive:'))
+        self._display_progress(ship_class, components)
         components.append(self._select(self.shield_generators, '\nSelect shield generator:'))
+        self._display_progress(ship_class, components)
         components.append(self._select(self.computer_cores, '\nSelect computer core:'))
+        self._display_progress(ship_class, components)
         components.append(self._select(self.sensor_arrays, '\nSelect sensor array:'))
+        self._display_progress(ship_class, components)
 
         # Optional components
         if input('Add science lab? (y/n): ').lower().startswith('y'):
             components.append(self._select(self.science_labs, '\nSelect science lab:'))
+            self._display_progress(ship_class, components)
         if input('Add transporter? (y/n): ').lower().startswith('y'):
             components.append(self._select(self.transporters, '\nSelect transporter:'))
+            self._display_progress(ship_class, components)
 
         phaser_slots = sum(1 for mp in ship_class.mount_points if mp['type'] == 'phaser_bank')
         torpedo_slots = sum(1 for mp in ship_class.mount_points if mp['type'] == 'photon_torpedo')
@@ -65,6 +101,7 @@ class ShipBuilder:
         for _ in range(phaser_slots):
             if input('Add phaser bank? (y/n): ').lower().startswith('y'):
                 components.append(self._select(self.phaser_banks, 'Select phaser bank:'))
+                self._display_progress(ship_class, components)
             else:
                 break
 
@@ -72,9 +109,11 @@ class ShipBuilder:
         for _ in range(torpedo_slots):
             if input('Add photon torpedo launcher? (y/n): ').lower().startswith('y'):
                 components.append(self._select(self.photon_torpedoes, 'Select torpedo launcher:'))
+                self._display_progress(ship_class, components)
             else:
                 break
 
+        self._display_progress(ship_class, components)
         ship = Ship(ship_class, components)
         errors = ship.validate()
         if errors:


### PR DESCRIPTION
## Summary
- keep track of ship stats while building
- display ASCII progress bars for mass, volume, power draw and crew after each component selection

## Testing
- `python -m py_compile ship_builder_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68585a333b80832e9015bd5a77206d47